### PR TITLE
feat: add GROMACS checkpointing and optional automatic lambda submission

### DIFF
--- a/ptmpsi/gromacs/__init__.py
+++ b/ptmpsi/gromacs/__init__.py
@@ -285,6 +285,7 @@ def generate_slurm(infile, posres=[1000.0,500.0,100.0,50.0,10.0,5.0,1.0],
             ipath = os.path.join(path, f"lam-{i:02d}")
             os.chdir(ipath)
             with open(f"{infile[:-4]}_lam{i:02d}_slurm.sbatch","w") as fh:
+                slurm.update_jobname(f"{jobname}_lam{i:02d}")
                 fh.write(slurm.header)
                 fh.write(f"cd 01-q\n")
                 fh.write(f"ln -s ../rankfile1 rankfile1 \n")

--- a/ptmpsi/gromacs/__init__.py
+++ b/ptmpsi/gromacs/__init__.py
@@ -244,7 +244,7 @@ def generate_slurm(infile, posres=[1000.0,500.0,100.0,50.0,10.0,5.0,1.0],
         fh.write(f"{single_mpiexec} {container} {gmx} grompp -f md.mdp -c fnpt.gro -t fnpt.cpt -p topol.top -n index.ndx -o md.tpr\n")
 
         if checkpointing:
-            fh.write(queue_estimated_runs.format(log_file='fnpt.log', mdp_file='md.mdp', submit_cmd=submit_cmd, dependency=dependency, sed=sed))
+            fh.write(queue_estimated_runs.format(log_file='fnpt.log', mdp_file='md.mdp', submit_cmd=submit_cmd, dependency=dependency, sed=sed, job_hours={slurm.get_time_hours()}))
             if auto_submit_ti:
                 fh.write(submit_lambdas)
             checkpoint_arg = "-cpi md.cpt"

--- a/ptmpsi/gromacs/__init__.py
+++ b/ptmpsi/gromacs/__init__.py
@@ -244,7 +244,7 @@ def generate_slurm(infile, posres=[1000.0,500.0,100.0,50.0,10.0,5.0,1.0],
         fh.write(f"{single_mpiexec} {container} {gmx} grompp -f md.mdp -c fnpt.gro -t fnpt.cpt -p topol.top -n index.ndx -o md.tpr\n")
 
         if checkpointing:
-            fh.write(queue_estimated_runs.format(log_file='fnpt.log', mdp_file='md.mdp', submit_cmd=submit_cmd, dependency=dependency, sed=sed, job_hours={slurm.get_time_hours()}))
+            fh.write(queue_estimated_runs.format(log_file='fnpt.log', mdp_file='md.mdp', submit_cmd=submit_cmd, dependency=dependency, sed=sed, job_hours=slurm.get_time_hours()))
             if auto_submit_ti:
                 fh.write(submit_lambdas)
             checkpoint_arg = "-cpi md.cpt"

--- a/ptmpsi/gromacs/templates.py
+++ b/ptmpsi/gromacs/templates.py
@@ -942,9 +942,9 @@ estimated_hours=$(echo "$total_ns * $hours_per_ns" | bc -l)
 echo "Estimated number of hours: $estimated_hours"
 
 # Calculate number of runs needed
-num_runs=$(echo "($estimated_hours / $max_hours)" | bc)
-remainder=$(echo "$estimated_hours % $max_hours" | bc)
-if [ "$remainder" -gt 0 ]; then
+num_runs=$(echo "($estimated_hours / {job_hours})" | bc)
+remainder=$(echo "$estimated_hours % {job_hours}" | bc)
+if [ "$(echo "$remainder > 0" | bc)" -eq 1 ]; then
   num_runs=$(echo "$num_runs + 1" | bc)
 fi
 

--- a/ptmpsi/gromacs/templates.py
+++ b/ptmpsi/gromacs/templates.py
@@ -976,7 +976,7 @@ echo "Submitting lambdas"
 """
 check_and_update_topology = """
 file_jobid=$(cat {job}.jobid)
-self_jobid=${self_jobid}
+self_jobid={self_jobid}
 if [ $file_jobid -eq $self_jobid ]; then
   echo "This is the last {job} job. Checking to see if requested steps match completed steps."
   requested_nsteps=$(grep nsteps {job}.mdp | awk '{{print $3}}')

--- a/ptmpsi/gromacs/templates.py
+++ b/ptmpsi/gromacs/templates.py
@@ -978,7 +978,14 @@ check_and_update_topology = """
 file_jobid=$(cat {job}.jobid)
 self_jobid=${self_jobid}
 if [ $file_jobid -eq $self_jobid ]; then
-  echo "This is the last {job} job."
+  echo "This is the last {job} job. Checking to see if requested steps match completed steps."
+  requested_nsteps=$(grep nsteps {job}.mdp | awk '{{print $3}}')
+  completed_nsteps=$(grep "Writing checkpoint, step" {job}.log | tail -1 | awk '{{print $4}}')
+  if [ $requested_nsteps -eq $completed_nsteps ]; then
+    echo "nsteps completed match the requested nsteps! $completed_nsteps steps completed."
+  else
+    echo "WARNING: nsteps completed ($completed_nsteps) do not match the requested nsteps ($requested_nsteps)."
+  fi
   echo "Updating topology whether nsteps was achieved or not."
   cd dualti
   python update_topology.py

--- a/ptmpsi/gromacs/templates.py
+++ b/ptmpsi/gromacs/templates.py
@@ -935,28 +935,24 @@ hours_per_ns=$(grep "Performance:" "{log_file}" | awk '{{print $3}}')
 dt=$(grep "^dt" "{mdp_file}" | awk '{{print $3}}')
 nsteps=$(grep "^nsteps" "{mdp_file}" | awk '{{print $3}}')
 
-total_ns=$(echo "$dt * $nsteps / 1000" | bc -l)
+total_ns=$(echo "$dt * $nsteps / 1000" | bc)
 
-estimated_hours=$(echo "$total_ns * $hours_per_ns" | bc -l)
+estimated_hours=$(echo "$total_ns * $hours_per_ns" | bc)
 
 echo "Estimated number of hours: $estimated_hours"
 
 # Calculate number of runs needed
-num_runs=$(echo "($estimated_hours / {job_hours})" | bc)
-remainder=$(echo "$estimated_hours % {job_hours}" | bc)
-if [ "$(echo "$remainder > 0" | bc)" -eq 1 ]; then
-  num_runs=$(echo "$num_runs + 1" | bc)
-fi
+num_runs=$(echo "($estimated_hours / 2.0 + 0.5)" | bc -l)
+num_runs=$(printf "%.0f" "$num_runs")
 
 # Subtract num_runs by 1 to account for the first run aging in the queue
-num_runs=${{num_runs%.*}}
 if [ "$num_runs" -gt 0 ]; then
   num_runs=$(echo "$num_runs - 1" | bc)
 fi
 
-echo "Number of additional runs needed for $file: $num_runs"
-
 file=$(basename "{mdp_file}" .mdp)
+
+echo "Number of additional runs needed for $file: $num_runs"
 
 # Obtain the jobid of the first run
 jobid=$(cat ${{file}}.jobid)

--- a/ptmpsi/gromacs/templates.py
+++ b/ptmpsi/gromacs/templates.py
@@ -935,9 +935,9 @@ hours_per_ns=$(grep "Performance:" "{log_file}" | awk '{{print $3}}')
 dt=$(grep "^dt" "{mdp_file}" | awk '{{print $3}}')
 nsteps=$(grep "^nsteps" "{mdp_file}" | awk '{{print $3}}')
 
-total_ns=$(echo "$dt * $nsteps / 1000" | bc)
+total_ns=$(echo "$dt * $nsteps / 1000" | bc -l)
 
-estimated_hours=$(echo "$total_ns * $hours_per_ns" | bc)
+estimated_hours=$(echo "$total_ns * $hours_per_ns" | bc -l)
 
 echo "Estimated number of hours: $estimated_hours"
 

--- a/ptmpsi/protein/__init__.py
+++ b/ptmpsi/protein/__init__.py
@@ -429,7 +429,7 @@ class Protein:
                     submit.write(f"jobid=$({submit_cmd} {prefix}{j:04d}_slurm.sbatch {sed}) \n")
                     submit.write(f"Submitted {prefix}{j:04d}_slurm.sbatch as job id $jobid\n")
                     if checkpointing:
-                        submit.write(f"jobid=$({submit_cmd} md.sbatch {dependency}=afterok:$jobid {sed}) \n")
+                        submit.write(f"jobid=$({submit_cmd} {dependency}=afterok:$jobid md.sbatch {sed}) \n")
                         submit.write(f"Submitted md.sbatch as job id $jobid with a dependency on the previous job.\n")
                         submit.write(f"echo $jobid > md.jobid\n")
                     if do_ti:

--- a/ptmpsi/protein/__init__.py
+++ b/ptmpsi/protein/__init__.py
@@ -326,6 +326,7 @@ class Protein:
             submit_cmd = "sbatch"
             dependency = "--dependency"
             sed = "| sed 's/Submitted batch job //'"
+        auto_submit_ti = kwargs.get("auto_submit_ti", True)
         
         checkpointing = kwargs.get("checkpointing", True)
 
@@ -449,7 +450,7 @@ class Protein:
                         lambdas.write(f"cd ../ \n")
                         lambdas.close()
                         subprocess.run(["chmod", "+x", f"{jpath}/submit_lambdas.sh"])
-                        if not checkpointing:
+                        if not checkpointing and auto_submit_ti:
                             submit.write(f"./submit_lambdas.sh $jobid\n")
                     submit.write(f"cd {os.path.relpath(path, jpath)} \n")
                     submit.write(f"sleep 1s \n")

--- a/ptmpsi/protein/__init__.py
+++ b/ptmpsi/protein/__init__.py
@@ -318,6 +318,17 @@ class Protein:
         machine = kwargs.get("machine", "")
         machine = machine.capitalize()
 
+        if machine == "Polaris":
+            submit_cmd = "qsub"
+            dependency = "-W depend"
+            sed = ""
+        else:
+            submit_cmd = "sbatch"
+            dependency = "--dependency"
+            sed = "| sed 's/Submitted batch job //'"
+        
+        checkpointing = kwargs.get("checkpointing", True)
+
         ff = ff.lower()
         if ff not in ["amber99sb", "amber99zn", "amber14sb"]:
             KeyError(f"Forcefield '{ff}' not available")
@@ -415,21 +426,29 @@ class Protein:
 
                     # Update submission script
                     submit.write(f"cd {os.path.relpath(jpath, path)} \n")
-                    if machine == "Polaris":
-                        submit.write(f"jobid=$(qsub {prefix}{j:04d}_slurm.sbatch) \n")
-                    else:
-                        submit.write(f"jobid=$(sbatch {prefix}{j:04d}_slurm.sbatch | sed 's/Submitted batch job //') \n")
+                    submit.write(f"jobid=$({submit_cmd} {prefix}{j:04d}_slurm.sbatch {sed}) \n")
+                    if checkpointing:
+                        submit.write(f"jobid=$({submit_cmd} md.sbatch {dependency}=afterok:$jobid {sed}) \n")
+                        submit.write(f"echo $jobid > md.jobid\n")
                     if do_ti:
-                        submit.write(f"cd dualti\n")
+                        lambdas = open(f"{jpath}/submit_lambdas.sh", "w")
+                        lambdas.write("#!/bin/bash\n")
+                        lambdas.write("jobid=$1:-\"\"\n")
+                        lambdas.write(f"cd dualti\n")
                         for k in range(13):
-                            submit.write(f"cd lam-{k:02d}\n")
-                            if machine == "Polaris":
-                                submit.write(f"qsub -W depend=afterok:$jobid {prefix}{j:04d}_lam{k:02d}_slurm.sbatch\n")
-                            else:
-                                submit.write(f"sbatch --dependency=afterok:$jobid {prefix}{j:04d}_lam{k:02d}_slurm.sbatch\n")
-                            submit.write(f"cd ../ \n")
-                            submit.write(f"sleep 1s \n")
-                        submit.write(f"cd ../ \n")
+                            lambdas.write(f"cd lam-{k:02d}\n")
+                            lambdas.write(f"if [ -z \"$jobid\" ]; then\n")
+                            lambdas.write(f"  {submit_cmd} {prefix}{j:04d}_lam{k:02d}_slurm.sbatch\n")
+                            lambdas.write(f"else\n")
+                            lambdas.write(f"  {submit_cmd} {dependency}=afterok:$jobid {prefix}{j:04d}_lam{k:02d}_slurm.sbatch\n")
+                            lambdas.write(f"fi\n")
+                            lambdas.write(f"cd ../ \n")
+                            lambdas.write(f"sleep 1s \n")
+                        lambdas.write(f"cd ../ \n")
+                        lambdas.close()
+                        subprocess.run(["chmod", "+x", f"{jpath}/submit_lambdas.sh"])
+                        if not checkpointing:
+                            submit.write(f"./submit_lambdas.sh $jobid\n")
                     submit.write(f"cd {os.path.relpath(path, jpath)} \n")
                     submit.write(f"sleep 1s \n")
                     submit.write(f"\n\n")

--- a/ptmpsi/protein/__init__.py
+++ b/ptmpsi/protein/__init__.py
@@ -427,15 +427,15 @@ class Protein:
                     # Update submission script
                     submit.write(f"cd {os.path.relpath(jpath, path)} \n")
                     submit.write(f"jobid=$({submit_cmd} {prefix}{j:04d}_slurm.sbatch {sed}) \n")
-                    submit.write(f"Submitted {prefix}{j:04d}_slurm.sbatch as job id $jobid\n")
+                    submit.write(f"echo \"Submitted {prefix}{j:04d}_slurm.sbatch as job id $jobid\"\n")
                     if checkpointing:
                         submit.write(f"jobid=$({submit_cmd} {dependency}=afterok:$jobid md.sbatch {sed}) \n")
-                        submit.write(f"Submitted md.sbatch as job id $jobid with a dependency on the previous job.\n")
+                        submit.write(f"echo \"Submitted md.sbatch as job id $jobid with a dependency on the previous job.\"\n")
                         submit.write(f"echo $jobid > md.jobid\n")
                     if do_ti:
                         lambdas = open(f"{jpath}/submit_lambdas.sh", "w")
                         lambdas.write("#!/bin/bash\n")
-                        lambdas.write("jobid=$1:-\"\"\n")
+                        lambdas.write("jobid=${1:-\"\"}\n")
                         lambdas.write(f"cd dualti\n")
                         for k in range(13):
                             lambdas.write(f"cd lam-{k:02d}\n")

--- a/ptmpsi/protein/__init__.py
+++ b/ptmpsi/protein/__init__.py
@@ -427,8 +427,10 @@ class Protein:
                     # Update submission script
                     submit.write(f"cd {os.path.relpath(jpath, path)} \n")
                     submit.write(f"jobid=$({submit_cmd} {prefix}{j:04d}_slurm.sbatch {sed}) \n")
+                    submit.write(f"Submitted {prefix}{j:04d}_slurm.sbatch as job id $jobid\n")
                     if checkpointing:
                         submit.write(f"jobid=$({submit_cmd} md.sbatch {dependency}=afterok:$jobid {sed}) \n")
+                        submit.write(f"Submitted md.sbatch as job id $jobid with a dependency on the previous job.\n")
                         submit.write(f"echo $jobid > md.jobid\n")
                     if do_ti:
                         lambdas = open(f"{jpath}/submit_lambdas.sh", "w")

--- a/ptmpsi/slurm/__init__.py
+++ b/ptmpsi/slurm/__init__.py
@@ -307,7 +307,10 @@ class Slurm:
         _time = kwargs.pop("time", _partition.maxtime if _partition.maxtime > 0 else 144)
         if _partition.maxtime > 0 and _time > _partition.maxtime:
             raise KeyError(f"Partition '{self.partition}' has a maximum time policy of '{_partition.maxtime}' per job")
-        self.time = f"{_time}:00:00"
+        hours = int(_time)
+        minutes = int((_time - hours) * 60)
+        seconds = int(((_time - hours) * 60 - minutes) * 60)
+        self.time = f"{hours:02}:{minutes:02}:{seconds:02}"
 
         self.account = kwargs.pop("account", self.machine.default_account())
 
@@ -340,6 +343,14 @@ class Slurm:
 
         self.header = self._header_template.format(**self.options_dictionary)
 
+        return
+    def get_time_hours(self):
+        hours, minutes, seconds = map(int, self.time.split(":"))
+        return float(hours) + float(minutes) / 60 + float(seconds) / 3600
+    def update_jobname(self, jobname):
+        self.jobname = jobname
+        self.options_dictionary["jname"] = self.jobname
+        self.header = self._header_template.format(**self.options_dictionary)
         return
 
 


### PR DESCRIPTION
This adds GROMACS checkpointing, addressing #22. Additionally, lambda submission is optional now. Both checkpointing and automatic lambda submission is on by default, but can be turned off in `gen_ptm_files()` with the `auto_submit_ti=False` argument disabling auto lambda submission, and the `checkpointing=False` disabling checkpointing.